### PR TITLE
Add ignore patterns

### DIFF
--- a/spring-rewrite-commons-functional-tests/private-artifact-repository-tests/src/test/java/org/springframework/sbm/PrivateArtifactRepositoryTest.java
+++ b/spring-rewrite-commons-functional-tests/private-artifact-repository-tests/src/test/java/org/springframework/sbm/PrivateArtifactRepositoryTest.java
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.rewrite.boot.autoconfigure.SbmSupportRewriteConfiguration;
+import org.springframework.rewrite.boot.autoconfigure.SpringRewriteCommonsConfiguration;
 import org.springframework.rewrite.parsers.RewriteProjectParser;
 import org.springframework.rewrite.parsers.RewriteProjectParsingResult;
 import org.springframework.rewrite.parsers.maven.SbmTestConfiguration;
@@ -86,7 +86,7 @@ import static org.assertj.core.api.Fail.fail;
  *
  * @author Fabian Krüger
  */
-@SpringBootTest(classes = { MavenArtifactCacheTestConfig.class, SbmSupportRewriteConfiguration.class,
+@SpringBootTest(classes = { MavenArtifactCacheTestConfig.class, SpringRewriteCommonsConfiguration.class,
 		SbmTestConfiguration.class })
 @Testcontainers
 public class PrivateArtifactRepositoryTest {

--- a/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/boot/autoconfigure/SpringRewriteCommonsConfiguration.java
+++ b/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/boot/autoconfigure/SpringRewriteCommonsConfiguration.java
@@ -26,6 +26,6 @@ import org.springframework.rewrite.parsers.RewriteParserConfiguration;
  */
 @AutoConfiguration
 @Import({ RecipeDiscoveryConfiguration.class, RewriteParserConfiguration.class, ProjectResourceSetConfiguration.class })
-public class SbmSupportRewriteConfiguration {
+public class SpringRewriteCommonsConfiguration {
 
 }

--- a/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/RewriteResourceParser.java
+++ b/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/RewriteResourceParser.java
@@ -184,14 +184,13 @@ public class RewriteResourceParser {
 
 		QuarkParser quarkParser = new QuarkParser();
 
-		filteredResources.forEach(resource -> {
+		resourcesLeft.forEach(path -> {
 			// See
 			// https://github.com/quarkusio/quarkus/blob/main/devtools/project-core-extension-codestarts/src/main/resources/codestarts/quarkus/extension-codestarts/resteasy-reactive-codestart/java/src/main/java/org/acme/%7Bresource.class-name%7D.tpl.qute.java
 			// for an example of why we don't want qute files be parsed as java
-			Path path = ResourceUtil.getPath(resource);
-			// if (javaParser.accept(path) && !path.toString().endsWith(".qute.java")) {
-			// javaPaths.add(path);
-			// }
+			if (javaParser.accept(path) && !path.toString().endsWith(".qute.java")) {
+				javaPaths.add(path);
+			}
 			if (jsonParser.accept(path)) {
 				jsonPaths.add(path);
 			}
@@ -209,7 +208,8 @@ public class RewriteResourceParser {
 			}
 			/*
 			 * else if(pythonParser.accept(path)) { pythonPaths.add(path); }
-			 */ else if (hclParser.accept(path)) {
+			 */
+			else if (hclParser.accept(path)) {
 				hclPaths.add(path);
 			}
 			else if (quarkParser.accept(path)) {

--- a/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/SpringRewriteProperties.java
+++ b/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/SpringRewriteProperties.java
@@ -57,7 +57,7 @@ public class SpringRewriteProperties {
 	 * Comma-separated list of patterns used to create PathMatcher The pattern should not
 	 * contain a leading 'glob:'
 	 */
-	private Set<String> plainTextMasks = Set.of("*.txt");
+	private Set<String> plainTextMasks = Set.of("**.txt");
 
 	/**
 	 * Project resources exceeding this threshold will not be parsed and provided as
@@ -80,7 +80,7 @@ public class SpringRewriteProperties {
 	 * being parsed.
 	 */
 	private Set<String> ignoredPathPatterns = Set.of("**/target/**", "target/**", "**/.idea/**", ".idea/**", ".mvn/**",
-			"**/.mvn/**", "**.git/**");
+			"**/.mvn/**", "**.git/**", "**/lib/**", "**/.gitignore");
 
 	/**
 	 * Whether the discovery should fail on invalid active recipes. TODO: Move to

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/CompareParserRecipeRunTest.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/CompareParserRecipeRunTest.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.rewrite.parsers;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
@@ -29,7 +28,7 @@ import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.rewrite.boot.autoconfigure.SbmSupportRewriteConfiguration;
+import org.springframework.rewrite.boot.autoconfigure.SpringRewriteCommonsConfiguration;
 import org.springframework.rewrite.parsers.maven.RewriteMavenProjectParser;
 import org.springframework.rewrite.parsers.maven.SbmTestConfiguration;
 import org.springframework.rewrite.test.util.ParallelParsingResult;
@@ -45,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Fabian Krüger
  */
-@SpringBootTest(classes = { SbmSupportRewriteConfiguration.class, SbmTestConfiguration.class })
+@SpringBootTest(classes = { SpringRewriteCommonsConfiguration.class, SbmTestConfiguration.class })
 public class CompareParserRecipeRunTest {
 
 	@Autowired

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/RewriteProjectParserIntegrationTest.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/RewriteProjectParserIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junitpioneer.jupiter.Issue;
 import org.openrewrite.java.tree.J;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.rewrite.boot.autoconfigure.SbmSupportRewriteConfiguration;
+import org.springframework.rewrite.boot.autoconfigure.SpringRewriteCommonsConfiguration;
 import org.springframework.rewrite.parsers.maven.RewriteMavenProjectParser;
 import org.springframework.rewrite.parsers.maven.SbmTestConfiguration;
 import org.springframework.rewrite.test.util.ParserParityTestHelper;
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "The repository URIs of dependencies differ.")
 @Issue("https://github.com/spring-projects/spring-rewrite-commons/issues/12")
-@SpringBootTest(classes = { SbmSupportRewriteConfiguration.class, SbmTestConfiguration.class })
+@SpringBootTest(classes = { SpringRewriteCommonsConfiguration.class, SbmTestConfiguration.class })
 public class RewriteProjectParserIntegrationTest {
 
 	@Autowired

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/RewriteResourceParserTest.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/RewriteResourceParserTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.rewrite.parsers;
+
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.quark.Quark;
+import org.openrewrite.text.PlainText;
+import org.slf4j.LoggerFactory;
+import org.springframework.rewrite.test.util.DummyResource;
+import org.springframework.rewrite.test.util.TestProjectHelper;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Fabian Krüger
+ */
+public class RewriteResourceParserTest {
+
+	@Test
+	@DisplayName("should parse resources matching plain text mask")
+	void shouldParseAsText(@TempDir Path baseDir) {
+		List<String> plainTextMask = List.of("**.txt");
+		DummyResource someText = new DummyResource(baseDir.resolve("src/main/resources/i-am-text.txt"), "some text");
+		new TestProjectHelper(baseDir).withResources(someText).writeToFilesystem();
+		Log logger = new Slf4jToMavenLoggerAdapter(LoggerFactory.getLogger(RewriteResourceParserTest.class));
+		RewriteResourceParser resourceParser = new RewriteResourceParser(baseDir, new ArrayList<String>(),
+				plainTextMask, 11, new ArrayList<Path>(), JavaParser.fromJavaVersion(), new RewriteExecutionContext());
+		List<SourceFile> sourceFiles = resourceParser.parse(baseDir, List.of(someText), new HashSet<>()).toList();
+		SourceFile parse = sourceFiles.get(0);
+		assertThat(sourceFiles).hasSize(1);
+		assertThat(parse).isInstanceOf(PlainText.class);
+		assertThat(parse.printAll()).isEqualTo("some text");
+	}
+
+	@Test
+	@DisplayName("should parse resources not matching plain text mask as Quark")
+	void shouldParseAsQuark(@TempDir Path baseDir) {
+		List<String> plainTextMask = List.of("**.foo");
+		DummyResource someText = new DummyResource(baseDir.resolve("src/main/resources/i-am-text.txt"), "some text");
+		new TestProjectHelper(baseDir).withResources(someText).writeToFilesystem();
+		Log logger = new Slf4jToMavenLoggerAdapter(LoggerFactory.getLogger(RewriteResourceParserTest.class));
+		RewriteResourceParser resourceParser = new RewriteResourceParser(baseDir, new ArrayList<String>(),
+				plainTextMask, 11, new ArrayList<Path>(), JavaParser.fromJavaVersion(), new RewriteExecutionContext());
+		List<SourceFile> sourceFiles = resourceParser.parse(baseDir, List.of(someText), new HashSet<>()).toList();
+		SourceFile parse = sourceFiles.get(0);
+		assertThat(sourceFiles).hasSize(1);
+		assertThat(parse).isInstanceOf(Quark.class);
+		assertThat(parse.printAll()).isEqualTo(""); // no access to content
+	}
+
+}

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/SpringRewritePropertiesTest.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/SpringRewritePropertiesTest.java
@@ -57,7 +57,7 @@ class SpringRewritePropertiesTest {
 		@Test
 		@DisplayName("spring.rewrite.plainTextMasks")
 		void defaultPlainTextMasks() {
-			assertThat(springRewriteProperties.getPlainTextMasks()).containsExactlyInAnyOrder("*.txt");
+			assertThat(springRewriteProperties.getPlainTextMasks()).containsExactlyInAnyOrder("**.txt");
 		}
 
 		@Test
@@ -88,7 +88,8 @@ class SpringRewritePropertiesTest {
 		@DisplayName("spring.rewrite.ignoredPathPatterns")
 		void defaultIgnoredPathPatterns() {
 			assertThat(springRewriteProperties.getIgnoredPathPatterns()).containsExactlyInAnyOrder(".idea/**",
-					"**/.idea/**", ".mvn/**", "**/.mvn/**", "**/target/**", "**.git/**", "target/**");
+					"**/.idea/**", ".mvn/**", "**/.mvn/**", "**/target/**", "**.git/**", "target/**", "**/.gitignore",
+					"**/lib/**");
 		}
 
 	}

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/maven/RewriteMavenProjectParserIntegrationTest.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/parsers/maven/RewriteMavenProjectParserIntegrationTest.java
@@ -26,7 +26,7 @@ import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.rewrite.boot.autoconfigure.SbmSupportRewriteConfiguration;
+import org.springframework.rewrite.boot.autoconfigure.SpringRewriteCommonsConfiguration;
 import org.springframework.rewrite.parsers.RewriteProjectParsingResult;
 import org.springframework.rewrite.parsers.events.FinishedParsingResourceEvent;
 
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Fabian Krüger
  */
-@SpringBootTest(classes = { SbmSupportRewriteConfiguration.class, SbmTestConfiguration.class })
+@SpringBootTest(classes = { SpringRewriteCommonsConfiguration.class, SbmTestConfiguration.class })
 public class RewriteMavenProjectParserIntegrationTest {
 
 	@Autowired

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/test/util/ParserExecutionHelper.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/test/util/ParserExecutionHelper.java
@@ -20,7 +20,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.rewrite.boot.autoconfigure.SbmSupportRewriteConfiguration;
+import org.springframework.rewrite.boot.autoconfigure.SpringRewriteCommonsConfiguration;
 import org.springframework.rewrite.parsers.SpringRewriteProperties;
 import org.springframework.rewrite.parsers.RewriteProjectParser;
 import org.springframework.rewrite.parsers.RewriteProjectParsingResult;
@@ -109,7 +109,7 @@ public class ParserExecutionHelper {
 	public RewriteProjectParsingResult parseWithRewriteProjectParser(Path baseDir,
 			SpringRewriteProperties springRewriteProperties) {
 		AtomicReference<RewriteProjectParsingResult> atomicRef = new AtomicReference<>();
-		new ApplicationContextRunner().withUserConfiguration(SbmSupportRewriteConfiguration.class)
+		new ApplicationContextRunner().withUserConfiguration(SpringRewriteCommonsConfiguration.class)
 			.withBean("spring.rewrite-" + SpringRewriteProperties.class.getName(), SpringRewriteProperties.class,
 					() -> springRewriteProperties)
 			.run(appCtx -> {

--- a/spring-rewrite-commons-launcher/src/test/resources/i-am-text.txt
+++ b/spring-rewrite-commons-launcher/src/test/resources/i-am-text.txt
@@ -1,0 +1,1 @@
+some text


### PR DESCRIPTION
Fix some problems that surfaced while introducing this project to SBM.

- `.gitignore` and `lib` dir are ignored now.
- Fix plainTextMask to `**.txt``
- Fix RewriteResource Parser which parsed text files as `Quark`s