### PR TITLE
Add new maker ClasspathDependencies

### DIFF
--- a/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/maven/ClasspathDependencies.java
+++ b/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/maven/ClasspathDependencies.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.rewrite.parsers.maven;
+
+import org.openrewrite.marker.Marker;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @author Fabian Krüger
+ */
+public class ClasspathDependencies implements Marker {
+
+	private List<Path> dependencies;
+
+	private final UUID id;
+
+	public ClasspathDependencies(List<Path> dependencies) {
+		this.dependencies = dependencies;
+		this.id = UUID.randomUUID();
+	}
+
+	private ClasspathDependencies(UUID id, List<Path> dependencies) {
+		this.id = id;
+		this.dependencies = dependencies;
+	}
+
+	public void setDependencies(List<Path> dependencies) {
+		this.dependencies = dependencies;
+	}
+
+	public List<Path> getDependencies() {
+		return dependencies;
+	}
+
+	@Override
+	public UUID getId() {
+		return id;
+	}
+
+	@Override
+	public ClasspathDependencies withId(UUID id) {
+		return new ClasspathDependencies(id, dependencies);
+	}
+
+}

--- a/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/maven/MavenModuleParser.java
+++ b/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parsers/maven/MavenModuleParser.java
@@ -224,7 +224,6 @@ public class MavenModuleParser {
 		LOGGER.info("Parsing main Java sources.");
 
 		Set<JavaType.FullyQualified> localClassesCp = new HashSet<>();
-		JavaSourceSet javaSourceSet = sourceSet("main", dependencies, typeCache);
 		List<? extends SourceFile> cus = javaParserBuilder.build()
 			.parseInputs(inputs, baseDir, executionContext)
 			.peek(s -> {
@@ -244,9 +243,12 @@ public class MavenModuleParser {
 		// The actual parsing happens when the stream is terminated (toList),
 		// therefore the toList() must be called before the parsed compilation units can
 		// be added to the classpath
+		JavaSourceSet javaSourceSet = sourceSet("main", dependencies, typeCache);
 		List<Marker> mainProjectProvenance = new ArrayList<>(provenanceMarkers);
 		javaSourceSet = appendToClasspath(localClassesCp, javaSourceSet);
 		mainProjectProvenance.add(javaSourceSet);
+		ClasspathDependencies classpathDependencies = new ClasspathDependencies(dependencies);
+		mainProjectProvenance.add(classpathDependencies);
 
 		List<Path> parsedJavaPaths = javaSourcesInTarget.stream().map(ResourceUtil::getPath).toList();
 		Stream<SourceFile> parsedMainJava = cus.stream()

--- a/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/test/util/ParserParityTestHelper.java
+++ b/spring-rewrite-commons-launcher/src/test/java/org/springframework/rewrite/test/util/ParserParityTestHelper.java
@@ -239,7 +239,9 @@ public class ParserParityTestHelper {
 			Markers givenMarkers = curGivenSourceFile.getMarkers();
 			List<Marker> actualMarkersList = givenMarkers.getMarkers();
 
-			assertThat(actualMarkersList.size()).isEqualTo(expectedMarkersList.size());
+			assertThat(actualMarkersList.stream().map(m -> m.getClass().getSimpleName()).toList())
+				.containsAll(expectedMarkersList.stream().map(m -> m.getClass().getSimpleName()).toList()); // ClasspathDependencies
+																											// marker
 
 			SoftAssertions softAssertions = new SoftAssertions();
 


### PR DESCRIPTION
Add a new `ClasspathDependencies` Marker to Java classes.
The marker contains the list of `Path`s of the jars that build the classpath.
It can be used to provide a classpath when creating a `JavaParser`.