### PR TITLE
Add starter for Boot upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,9 @@
 
     <modules>
         <module>spring-rewrite-commons-launcher</module>
-                <module>spring-rewrite-commons-docs</module>
-                <module>spring-rewrite-commons-examples</module>
+        <module>spring-rewrite-commons-docs</module>
+        <module>spring-rewrite-commons-examples</module>
+        <module>spring-rewrite-commons-starters</module>
         <!--        <module>spring-rewrite-commons-gradle</module>-->
     </modules>
 

--- a/spring-rewrite-commons-examples/boot-3-upgrade-atomic-example/pom.xml
+++ b/spring-rewrite-commons-examples/boot-3-upgrade-atomic-example/pom.xml
@@ -23,18 +23,6 @@
         <spring-boot.version>3.1.3</spring-boot.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/spring-rewrite-commons-examples/list-applicable-recipes-example/pom.xml
+++ b/spring-rewrite-commons-examples/list-applicable-recipes-example/pom.xml
@@ -22,30 +22,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.openrewrite.recipe</groupId>
-			<artifactId>rewrite-migrate-java</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.openrewrite.recipe</groupId>
-			<artifactId>rewrite-spring</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.openrewrite.recipe</groupId>
-			<artifactId>rewrite-hibernate</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.openrewrite.recipe</groupId>
-			<artifactId>rewrite-java-dependencies</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.openrewrite.recipe</groupId>
-			<artifactId>rewrite-testing-frameworks</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.openrewrite.recipe</groupId>
-			<artifactId>rewrite-static-analysis</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/spring-rewrite-commons-examples/pom.xml
+++ b/spring-rewrite-commons-examples/pom.xml
@@ -31,35 +31,33 @@
         <dependencies>
             <dependency>
                 <groupId>org.springframework.rewrite</groupId>
-                <artifactId>spring-rewrite-commons-launcher</artifactId>
+                <artifactId>spring-rewrite-commons-starter-boot-upgrade</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.openrewrite.recipe</groupId>
-                <artifactId>rewrite-recipe-bom</artifactId>
-                <version>${rewrite-recipe-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.boot</groupId>-->
+<!--            <artifactId>spring-boot-starter</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.springframework.rewrite</groupId>-->
+<!--            <artifactId>spring-rewrite-commons-launcher</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.openrewrite.recipe</groupId>-->
+<!--            <artifactId>rewrite-spring</artifactId>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.openrewrite.recipe</groupId>-->
+<!--            <artifactId>rewrite-migrate-java</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.springframework.rewrite</groupId>
-            <artifactId>spring-rewrite-commons-launcher</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openrewrite.recipe</groupId>
-            <artifactId>rewrite-spring</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openrewrite.recipe</groupId>
-            <artifactId>rewrite-migrate-java</artifactId>
+            <artifactId>spring-rewrite-commons-starter-boot-upgrade</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/spring-rewrite-commons-starters/pom.xml
+++ b/spring-rewrite-commons-starters/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.rewrite</groupId>
+        <artifactId>spring-rewrite-commons</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+
+    <artifactId>spring-rewrite-commons-starters</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>spring-rewrite-commons-starter-boot-upgrade</module>
+    </modules>
+
+</project>

--- a/spring-rewrite-commons-starters/spring-rewrite-commons-starter-boot-upgrade/pom.xml
+++ b/spring-rewrite-commons-starters/spring-rewrite-commons-starter-boot-upgrade/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.rewrite</groupId>
+        <artifactId>spring-rewrite-commons-starters</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>spring-rewrite-commons-starter-boot-upgrade</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <rewrite-recipe-bom.version>2.6.2</rewrite-recipe-bom.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-recipe-bom</artifactId>
+                <version>${rewrite-recipe-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.rewrite</groupId>
+            <artifactId>spring-rewrite-commons-launcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-migrate-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-hibernate</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-java-dependencies</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-testing-frameworks</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-static-analysis</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
Add a new module `spring-rewrite-commons-starter-boot-upgrade` which bundles the `spring-rewrite-commons-launcher` together with the required OpenRewrite recipe jars for Boot upgrades.
This module simplifies the creation of applications wanting to run OpenRewrite's Boot upgrade recipes.

````xml
  <dependency>
      <groupId>org.springframework.rewrite</groupId>
      <artifactId>spring-rewrite-commons-starter-boot-upgrade</artifactId>
      <version>0.1.0-SNAPSHOT</version>
  </dependency>
````

Brings everything that's required to apply e.g. `org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_1`.