### PR TITLE
Fix Maven project graph

### DIFF
--- a/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parser/maven/MavenProjectGraph.java
+++ b/spring-rewrite-commons-launcher/src/main/java/org/springframework/rewrite/parser/maven/MavenProjectGraph.java
@@ -78,8 +78,10 @@ public class MavenProjectGraph {
 	}
 
 	private void initGaToMavenProjectMap(List<MavenProject> allPomFiles) {
-		gaToMavenProjectMap = allPomFiles.stream()
-			.collect(Collectors.toMap(mp -> new ProjectId(mp.getGroupId(), mp.getArtifactId()), mp -> mp));
+		gaToMavenProjectMap = new HashMap<>();
+		allPomFiles.stream().forEach(mp -> {
+			gaToMavenProjectMap.putIfAbsent(new ProjectId(mp.getGroupId(), mp.getArtifactId()), mp);
+		});
 	}
 
 	private void buildDependencyGraph(MavenProject currentProject, List<MavenProject> reactorProjects,


### PR DESCRIPTION
Fix a problem with duplicate keys when creating a map from a list of poms containing poms with the same gav (e.g. in example projects).