### PR TITLE
Plugin invoker requires Maven plugin version

### DIFF
--- a/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-maven/src/main/java/org/springframework/rewrite/plugin/maven/RewriteMavenPluginBuilder.java
+++ b/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-maven/src/main/java/org/springframework/rewrite/plugin/maven/RewriteMavenPluginBuilder.java
@@ -26,11 +26,17 @@ public interface RewriteMavenPluginBuilder {
 
 	public interface Recipes {
 
-		FinalizingBuilder recipes(String... recipeNames);
+		MavenPLuginVersionBuilder recipes(String... recipeNames);
 
 	}
 
-	interface FinalizingBuilder {
+	interface MavenPLuginVersionBuilder {
+
+		FinalizingBuilder withMavenPluginVersion(String mavenPluginVersion);
+
+	}
+
+	interface FinalizingBuilder extends MavenPLuginVersionBuilder {
 
 		FinalizingBuilder withDependencies(String... dependencies);
 

--- a/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-maven/src/test/java/org/springframework/rewrite/plugin/maven/RewriteMavenPluginTest.java
+++ b/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-maven/src/test/java/org/springframework/rewrite/plugin/maven/RewriteMavenPluginTest.java
@@ -54,7 +54,10 @@ class RewriteMavenPluginTest {
 	void simpleProjectSimpleConfig() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
 
-		PluginInvocationResult result = RewriteMavenPlugin.run().recipes(RECIPES).onDir(baseDir);
+		PluginInvocationResult result = RewriteMavenPlugin.run()
+			.recipes(RECIPES)
+			.withMavenPluginVersion("5.32.1")
+			.onDir(baseDir);
 
 		String out = result.capturedOutput();
 		assertThat(result.success()).isTrue();
@@ -66,7 +69,10 @@ class RewriteMavenPluginTest {
 	@DisplayName("builder runNoFork")
 	void simpleProjectSimpleConfigRunNoFork() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
-		PluginInvocationResult result = RewriteMavenPlugin.runNoFork().recipes(RECIPES).onDir(baseDir);
+		PluginInvocationResult result = RewriteMavenPlugin.runNoFork()
+			.recipes(RECIPES)
+			.withMavenPluginVersion("5.32.1")
+			.onDir(baseDir);
 		String out = result.capturedOutput();
 		assertThat(result.success()).isTrue();
 		assertTasksExecuted(out, "runNoFork");
@@ -77,7 +83,10 @@ class RewriteMavenPluginTest {
 	@DisplayName("builder dryRun")
 	void simpleProjectSimpleConfigDryRun() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
-		PluginInvocationResult result = RewriteMavenPlugin.dryRun().recipes(RECIPES).onDir(baseDir);
+		PluginInvocationResult result = RewriteMavenPlugin.dryRun()
+			.recipes(RECIPES)
+			.withMavenPluginVersion("5.32.1")
+			.onDir(baseDir);
 		String out = result.capturedOutput();
 		assertThat(result.success()).isTrue();
 		assertTasksExecuted(out, tasksOf(DEFAULT_GOALS, "dryRun"));
@@ -88,7 +97,10 @@ class RewriteMavenPluginTest {
 	@DisplayName("builder dryRunNoFork")
 	void simpleProjectSimpleConfigDryRunNoFork() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
-		PluginInvocationResult result = RewriteMavenPlugin.dryRunNoFork().recipes(RECIPES).onDir(baseDir);
+		PluginInvocationResult result = RewriteMavenPlugin.dryRunNoFork()
+			.recipes(RECIPES)
+			.withMavenPluginVersion("5.32.1")
+			.onDir(baseDir);
 		String out = result.capturedOutput();
 		assertThat(result.success()).isTrue();
 		assertTasksExecuted(out, "dryRunNoFork");
@@ -99,7 +111,10 @@ class RewriteMavenPluginTest {
 	@DisplayName("builder discover")
 	void simpleProjectSimpleConfigDiscover() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
-		PluginInvocationResult result = RewriteMavenPlugin.discover().recipes(RECIPES).onDir(baseDir);
+		PluginInvocationResult result = RewriteMavenPlugin.discover()
+			.recipes(RECIPES)
+			.withMavenPluginVersion("5.32.1")
+			.onDir(baseDir);
 		String out = result.capturedOutput();
 		assertThat(result.success()).isTrue();
 		assertTasksExecuted(out, "discover");
@@ -110,7 +125,10 @@ class RewriteMavenPluginTest {
 	@DisplayName("builder cyclonedx")
 	void simpleProjectSimpleConfigCyclonedx() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
-		PluginInvocationResult result = RewriteMavenPlugin.cyclonedx().recipes(RECIPES).onDir(baseDir);
+		PluginInvocationResult result = RewriteMavenPlugin.cyclonedx()
+			.recipes(RECIPES)
+			.withMavenPluginVersion("5.32.1")
+			.onDir(baseDir);
 		String out = result.capturedOutput();
 		System.out.println(out);
 		assertThat(result.success()).isTrue();
@@ -125,6 +143,7 @@ class RewriteMavenPluginTest {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
 		PluginInvocationResult result = RewriteMavenPlugin.run()
 			.recipes(EXTENDED_RECIPES)
+			.withMavenPluginVersion("5.32.1")
 			.withDependencies(EXTENDED_REFCIPES_DEPS)
 			.withDebugger(port, false)
 			.withDebug()
@@ -145,9 +164,10 @@ class RewriteMavenPluginTest {
 
 		int port = TestSocketUtils.findAvailableTcpPort();
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
+		String rewriteMavenPluginVersion = "5.32.1";
 		MavenInvocationResult result = RewriteMavenPlugin.execute(baseDir, true, DebugConfig.from(port, false),
 				BuildConfig.builder().withMemory("1G", "4G").build(), RewriteMavenPlugin.Goal.DRY_RUN,
-				Arrays.asList(RECIPES), List.of());
+				Arrays.asList(RECIPES), List.of(), rewriteMavenPluginVersion);
 		String out = result.getCapturedLines();
 		assertDebugConfig(out, port, false);
 		assertMemory(out, "1G", "4G");
@@ -179,9 +199,10 @@ class RewriteMavenPluginTest {
 	@DisplayName("execute discover")
 	void executeDiscover() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
+		String rewriteMavenPluginVersion = "5.32.1";
 		MavenInvocationResult result = RewriteMavenPlugin.execute(baseDir, false, DebugConfig.disabled(),
 				BuildConfig.fromDefault(), RewriteMavenPlugin.Goal.DISCOVER, Arrays.asList(EXTENDED_RECIPES),
-				List.of(EXTENDED_REFCIPES_DEPS));
+				List.of(EXTENDED_REFCIPES_DEPS), rewriteMavenPluginVersion);
 		String out = result.getCapturedLines();
 		assertThat(result.getExitCode()).isEqualTo(0);
 		assertTasksExecuted(out, "discover");
@@ -192,17 +213,20 @@ class RewriteMavenPluginTest {
 	@DisplayName("execute cylonedx")
 	void executeCyclonedx() {
 		Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
+		String rewriteMavenPluginVersion = "5.32.1";
 		MavenInvocationResult result = RewriteMavenPlugin.execute(baseDir, false, DebugConfig.disabled(),
 				BuildConfig.fromDefault(), RewriteMavenPlugin.Goal.CYCLONEDX, Arrays.asList(EXTENDED_RECIPES),
-				List.of(EXTENDED_REFCIPES_DEPS));
+				List.of(EXTENDED_REFCIPES_DEPS), rewriteMavenPluginVersion);
 		String out = result.getCapturedLines();
 		assertThat(result.getExitCode()).isEqualTo(0);
 		assertTasksExecuted(out, "cyclonedx");
 	}
 
 	private void verify(Path baseDir, RewriteMavenPlugin.Goal runNoFork, String expectedGoal) {
+		String rewriteMavenPluginVersion = "5.32.1";
 		MavenInvocationResult result = RewriteMavenPlugin.execute(baseDir, false, DebugConfig.disabled(),
-				BuildConfig.fromDefault(), runNoFork, Arrays.asList(EXTENDED_RECIPES), List.of(EXTENDED_REFCIPES_DEPS));
+				BuildConfig.fromDefault(), runNoFork, Arrays.asList(EXTENDED_RECIPES), List.of(EXTENDED_REFCIPES_DEPS),
+				rewriteMavenPluginVersion);
 		String out = result.getCapturedLines();
 		assertThat(result.getExitCode()).isEqualTo(0);
 		assertRecipesExecuted(out, EXTENDED_RECIPES);

--- a/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-polyglot/src/main/java/org/springframework/rewrite/plugin/polyglot/RewritePlugin.java
+++ b/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-polyglot/src/main/java/org/springframework/rewrite/plugin/polyglot/RewritePlugin.java
@@ -42,6 +42,8 @@ public class RewritePlugin implements OpenRewritePluginBuilder.GradlePluginVersi
 
 	private String gradlePluginVersion;
 
+	private String mavenPluginVersion;
+
 	private List<String> recipes = new ArrayList<>();
 
 	private boolean debug;
@@ -77,6 +79,12 @@ public class RewritePlugin implements OpenRewritePluginBuilder.GradlePluginVersi
 	@Override
 	public OpenRewritePluginBuilder.Recipes gradlePluginVersion(String pluginVersion) {
 		this.gradlePluginVersion = pluginVersion;
+		return this;
+	}
+
+	@Override
+	public OpenRewritePluginBuilder.GradlePluginVersion mavenPluginVersion(String mavenPluginVersion) {
+		this.mavenPluginVersion = mavenPluginVersion;
 		return this;
 	}
 
@@ -151,7 +159,8 @@ public class RewritePlugin implements OpenRewritePluginBuilder.GradlePluginVersi
 			default -> builder = RewriteMavenPlugin.run();
 		}
 		RewriteMavenPluginBuilder.FinalizingBuilder finalizingBuilder = builder
-			.recipes(this.recipes.toArray(String[]::new));
+			.recipes(this.recipes.toArray(String[]::new))
+			.withMavenPluginVersion("5.32.1");
 		if (minMemory != null) {
 			finalizingBuilder = finalizingBuilder.withMemory(minMemory, maxMemory);
 		}
@@ -225,6 +234,8 @@ class OpenRewritePluginBuilder {
 	public interface GradlePluginVersion {
 
 		Recipes gradlePluginVersion(String pluginVersion);
+
+		GradlePluginVersion mavenPluginVersion(String s);
 
 	}
 

--- a/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-polyglot/src/test/java/org/springframework/rewrite/plugin/polyglot/RewritePluginTest.java
+++ b/spring-rewrite-commons-plugin-invoker/spring-rewrite-commons-plugin-invoker-polyglot/src/test/java/org/springframework/rewrite/plugin/polyglot/RewritePluginTest.java
@@ -118,6 +118,7 @@ public class RewritePluginTest {
 			int port = TestSocketUtils.findAvailableTcpPort();
 			Path baseDir = Path.of("./testcode/maven-projects/simple").toAbsolutePath().normalize();
 			PluginInvocationResult result = RewritePlugin.run()
+				.mavenPluginVersion("5.32.1")
 				.gradlePluginVersion("6.10.0")
 				.recipes(EXTENDED_RECIPES)
 				.dependencies(EXTENDED_RECIPES_DEPS)


### PR DESCRIPTION
The fluent API to execute the OpenRewrite Maven plugin expects a plugin version now.
The plugin version also defines the OR version that will be used.